### PR TITLE
Fix bug when decoding struct containing optional array of `Codable`-conforming struct

### DIFF
--- a/Sources/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/Decoder/UnkeyedDecodingContainer.swift
@@ -109,11 +109,17 @@ extension _CBORDecoder.UnkeyedContainer: UnkeyedDecodingContainer {
         }
         try checkCanDecodeValue()
         defer { self.currentIndex += 1 }
-
-        let container = self.nestedContainers[self.currentIndex] as! _CBORDecoder.SingleValueContainer
-        let value = container.decodeNil()
-
-        return value
+        
+        switch self.nestedContainers[self.currentIndex] {
+        case let singleValueContainer as _CBORDecoder.SingleValueContainer:
+            return singleValueContainer.decodeNil()
+        case is _CBORDecoder.UnkeyedContainer,
+            is _CBORDecoder.KeyedContainer<AnyCodingKey>:
+            return false
+        default:
+            let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "cannot decode nil for index: \(self.currentIndex)")
+            throw DecodingError.typeMismatch(Any?.self, context)
+        }
     }
 
     func decode<T: Decodable>(_ type: T.Type) throws -> T {

--- a/Sources/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/Decoder/UnkeyedDecodingContainer.swift
@@ -109,12 +109,11 @@ extension _CBORDecoder.UnkeyedContainer: UnkeyedDecodingContainer {
         }
         try checkCanDecodeValue()
         defer { self.currentIndex += 1 }
-        
+
         switch self.nestedContainers[self.currentIndex] {
         case let singleValueContainer as _CBORDecoder.SingleValueContainer:
             return singleValueContainer.decodeNil()
-        case is _CBORDecoder.UnkeyedContainer,
-            is _CBORDecoder.KeyedContainer<AnyCodingKey>:
+        case is _CBORDecoder.UnkeyedContainer, is _CBORDecoder.KeyedContainer<AnyCodingKey>:
             return false
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "cannot decode nil for index: \(self.currentIndex)")

--- a/Tests/CBORCodableRoundtripTests.swift
+++ b/Tests/CBORCodableRoundtripTests.swift
@@ -355,6 +355,25 @@ class CBORCodableRoundtripTests: XCTestCase {
         XCTAssertEqual(anyRecursive, decoded)
     }
 
+    func testOptionalArray() {
+        struct StructWithOptionalArray: Codable, Equatable {
+            var array: [InnerStruct]?
+        }
+
+        struct InnerStruct: Codable, Equatable {
+            var parameter: String
+        }
+
+        let test1 = StructWithOptionalArray(array: [InnerStruct(parameter: "present")])
+        let test2 = StructWithOptionalArray(array: nil)
+
+        for testVal in [test1, test2] {
+            let encoded = try! CodableCBOREncoder().encode(testVal)
+            let decoded = try! CodableCBORDecoder().decode(StructWithOptionalArray.self, from: encoded)
+            XCTAssertEqual(testVal, decoded)
+        }
+    }
+
     func testFoundationHeavyType() {
         struct FoundationLaden: Codable, Equatable {
             let date: Date


### PR DESCRIPTION
Closes: #88 