### PR TITLE
Fix building for Windows

### DIFF
--- a/Sources/CBOR.swift
+++ b/Sources/CBOR.swift
@@ -174,6 +174,6 @@ extension CBOR.Tag {
     public static let selfDescribeCBOR = CBOR.Tag(rawValue: 55799)
 }
 
-#if os(Linux)
+#if os(Linux) || os(Windows)
 let NSEC_PER_SEC: UInt64 = 1_000_000_000
 #endif


### PR DESCRIPTION
`NSEC_PER_SEC` cannot be found on Windows