### PR TITLE
Use `encodeVarUint()` method again for `UInt`

### DIFF
--- a/Sources/CBOREncodable.swift
+++ b/Sources/CBOREncodable.swift
@@ -106,7 +106,7 @@ extension Int64: CBOREncodable {
 
 extension UInt: CBOREncodable {
     public func encode(options: CBOROptions = CBOROptions()) -> [UInt8] {
-        return UInt64(self).encode(options: options)
+        return CBOR.encodeVarUInt(UInt64(self))
     }
 
     public func toCBOR(options: CBOROptions = CBOROptions()) -> CBOR {

--- a/Tests/CBOREncoderTests.swift
+++ b/Tests/CBOREncoderTests.swift
@@ -13,6 +13,7 @@ class CBOREncoderTests: XCTestCase {
             XCTAssertEqual((-i).encode().count, 1)
         }
         XCTAssertEqual(Int(-1).encode(), [0x20])
+        XCTAssertEqual(UInt(1).encode(), [0x1])
         XCTAssertEqual(CBOR.encode(-10), [0x29])
         XCTAssertEqual(Int(-24).encode(), [0x37])
         XCTAssertEqual(Int(-25).encode(), [0x38, 24])


### PR DESCRIPTION
Fixes https://github.com/valpackett/SwiftCBOR/issues/98