### PR TITLE
Added the ability to specify a maximum depth for CBOR decoding

### DIFF
--- a/Sources/CBORDecoder.swift
+++ b/Sources/CBORDecoder.swift
@@ -7,6 +7,7 @@ public enum CBORError : Error {
     case wrongTypeInsideSequence
     case tooLongSequence
     case incorrectUTF8String
+    case maximumDepthExceeded
 }
 
 extension CBOR {
@@ -18,6 +19,7 @@ extension CBOR {
 public class CBORDecoder {
     private var istream : CBORInputStream
     public var options: CBOROptions
+    private var currentDepth = 0
 
     public init(stream: CBORInputStream, options: CBOROptions = CBOROptions()) {
         self.istream = stream
@@ -108,6 +110,11 @@ public class CBORDecoder {
     }
 
     public func decodeItem() throws -> CBOR? {
+        guard currentDepth <= options.maximumDepth
+        else { throw CBORError.maximumDepthExceeded }
+        
+        currentDepth += 1
+        defer { currentDepth -= 1 }
         let b = try istream.popByte()
 
         switch b {

--- a/Sources/CBOROptions.swift
+++ b/Sources/CBOROptions.swift
@@ -2,15 +2,19 @@ public struct CBOROptions {
     let useStringKeys: Bool
     let dateStrategy: DateStrategy
     let forbidNonStringMapKeys: Bool
+    /// The maximum number of nested items, inclusive, to decode. A maximum set to 0 dissallows anything other than top-level primitives.
+    let maximumDepth: Int
 
     public init(
         useStringKeys: Bool = false,
         dateStrategy: DateStrategy = .taggedAsEpochTimestamp,
-        forbidNonStringMapKeys: Bool = false
+        forbidNonStringMapKeys: Bool = false,
+        maximumDepth: Int = .max
     ) {
         self.useStringKeys = useStringKeys
         self.dateStrategy = dateStrategy
         self.forbidNonStringMapKeys = forbidNonStringMapKeys
+        self.maximumDepth = maximumDepth
     }
 
     func toCodableEncoderOptions() -> CodableCBOREncoder._Options {
@@ -24,7 +28,8 @@ public struct CBOROptions {
     func toCodableDecoderOptions() -> CodableCBORDecoder._Options {
         return CodableCBORDecoder._Options(
             useStringKeys: self.useStringKeys,
-            dateStrategy: self.dateStrategy
+            dateStrategy: self.dateStrategy,
+            maximumDepth: self.maximumDepth
         )
     }
 }

--- a/Sources/Decoder/CodableCBORDecoder.swift
+++ b/Sources/Decoder/CodableCBORDecoder.swift
@@ -7,14 +7,24 @@ final public class CodableCBORDecoder {
     struct _Options {
         let useStringKeys: Bool
         let dateStrategy: DateStrategy
+        let maximumDepth: Int
 
-        init(useStringKeys: Bool = false, dateStrategy: DateStrategy = .taggedAsEpochTimestamp) {
+        init(
+            useStringKeys: Bool = false,
+            dateStrategy: DateStrategy = .taggedAsEpochTimestamp,
+            maximumDepth: Int = .max
+        ) {
             self.useStringKeys = useStringKeys
             self.dateStrategy = dateStrategy
+            self.maximumDepth = maximumDepth
         }
 
         func toCBOROptions() -> CBOROptions {
-            return CBOROptions(useStringKeys: self.useStringKeys, dateStrategy: self.dateStrategy)
+            return CBOROptions(
+                useStringKeys: self.useStringKeys,
+                dateStrategy: self.dateStrategy,
+                maximumDepth: self.maximumDepth
+            )
         }
     }
 


### PR DESCRIPTION
Added the ability to specify a maximum depth for CBOR decoding. This addresses a crash reported in #92 that can occur when certain types of data causes the recursive nature of the decoder to escape the stack for the given thread. I do suggest we set a more reasonable default than `.max`, though that can break some user's workflows if they weren't expecting it, so maybe requires a new version? Food for thought 😅