### PR TITLE
Fix Sendable error in Swift 6

### DIFF
--- a/Sources/CBOR.swift
+++ b/Sources/CBOR.swift
@@ -132,7 +132,7 @@ public indirect enum CBOR : Equatable, Hashable,
         }
     }
 
-    public struct Tag: RawRepresentable, Equatable, Hashable {
+    public struct Tag: RawRepresentable, Hashable {
         public let rawValue: UInt64
 
         public init(rawValue: UInt64) {

--- a/Sources/CBOR.swift
+++ b/Sources/CBOR.swift
@@ -132,7 +132,7 @@ public indirect enum CBOR : Equatable, Hashable,
         }
     }
 
-    public struct Tag: RawRepresentable, Hashable {
+    public struct Tag: RawRepresentable, Hashable, Sendable {
         public let rawValue: UInt64
 
         public init(rawValue: UInt64) {


### PR DESCRIPTION
Fix data racing error for Swift 6

```
Static property 'standardDateTimeString' is not concurrency-safe because non-'Sendable' type 'CBOR.Tag' may have shared mutable state
```