### PR TITLE
Adds tvOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftCBOR",
-    platforms: [.macOS(.v10_13), .iOS(.v13)],
+    platforms: [.macOS(.v10_13), .iOS(.v13), .tvOS(.v13)],
     products: [
         .library(name: "SwiftCBOR", targets: ["SwiftCBOR"])
     ],

--- a/SwiftCBOR.podspec
+++ b/SwiftCBOR.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.13'
+  s.tvos.deployment_target = '13.0'
 
   s.source_files = 'Sources/**/*.{swift,h}'
 


### PR DESCRIPTION
Adds tvOS support to both `Package.swift` and `SwiftCBOR.podspec`

I have tested (build, unit tests, and actual usage) this on as many tvOS simulators as I could and all seems well, but do not currently have access to tvOS hardware as a final sanity check.