### PR TITLE
Adds SPM support for Mac Catalyst

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       run: swift test
 
   macos:
-    name: macOS, iOS, tvOS (Xcode)
+    name: macOS, iOS, tvOS, Mac Catalyst (Xcode)
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
@@ -30,3 +30,5 @@ jobs:
       run: xcodebuild test -scheme SwiftCBOR -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest'
     - name: Test tvOS
       run: xcodebuild test -scheme SwiftCBOR -destination 'platform=tvOS Simulator,name=Any tvOS Simulator Device'
+    - name: Test Mac Catalyst
+      run: xcodebuild test -scheme SwiftCBOR -destination 'platform=macOS,variant=Mac Catalyst'

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftCBOR",
-    platforms: [.macOS(.v10_13), .iOS(.v13), .tvOS(.v13)],
+    platforms: [.macOS(.v10_13), .iOS(.v13), .tvOS(.v13), .macCatalyst(.v13)],
     products: [
         .library(name: "SwiftCBOR", targets: ["SwiftCBOR"])
     ],


### PR DESCRIPTION
This adds support for Mac Catalyst as a deployment target (for SPM, I couldn't find the appropriate `.podspec` syntax, if one exists).

I have confirmed that this works on my Mac. The unit tests pass, and it builds & works properly when integrated into another app that supports Mac Catalyst as a deployment target.